### PR TITLE
Port fabric-lifecycle-events-v1 to 25w14craftmine.

### DIFF
--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/GameInstanceMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/GameInstanceMixin.java
@@ -1,0 +1,73 @@
+package net.fabricmc.fabric.mixin.event.lifecycle;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
+
+import net.minecraft.class_10961;
+
+import net.minecraft.resource.LifecycledResourceManager;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Mixin(class_10961.class)
+public abstract class GameInstanceMixin {
+	@Shadow
+	public abstract MinecraftServer method_68961();
+
+	@Shadow
+	public abstract ResourceManager method_69006();
+
+	@WrapOperation(method = "method_68968", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+	private <K, V> V onLoadWorld(Map<K, V> worlds, K registryKey, V serverWorld, Operation<V> original) {
+		final V result = original.call(worlds, registryKey, serverWorld);
+		ServerWorldEvents.LOAD.invoker().onWorldLoad(this.method_68961(), (ServerWorld) serverWorld);
+
+		return result;
+	}
+
+	@Inject(method = "close", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;close()V"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
+	private void onUnloadWorldAtShutdown(CallbackInfo ci, Iterator<ServerWorld> worlds, ServerWorld world) {
+		ServerWorldEvents.UNLOAD.invoker().onWorldUnload(this.method_68961(), world);
+	}
+
+	@Inject(method = "method_68979", at = @At("HEAD"))
+	private void startResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
+		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().startDataPackReload(this.method_68961(), (LifecycledResourceManager) this.method_69006());
+	}
+
+	@Inject(method = "method_68979", at = @At("TAIL"))
+	private void endResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
+		cir.getReturnValue().handleAsync((value, throwable) -> {
+			// Hook into fail
+			ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload(this.method_68961(), (LifecycledResourceManager) this.method_69006(), throwable == null);
+			return value;
+		}, this.method_68961());
+	}
+
+	@Inject(method = "method_68984", at = @At("HEAD"))
+	private void startSave(boolean suppressLogs, boolean flush, boolean force, CallbackInfoReturnable<Boolean> cir) {
+		ServerLifecycleEvents.BEFORE_SAVE.invoker().onBeforeSave(this.method_68961(), flush, force);
+	}
+
+	@Inject(method = "method_68984", at = @At("TAIL"))
+	private void endSave(boolean suppressLogs, boolean flush, boolean force, CallbackInfoReturnable<Boolean> cir) {
+		ServerLifecycleEvents.AFTER_SAVE.invoker().onAfterSave(this.method_68961(), flush, force);
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MinecraftServerMixin.java
@@ -16,40 +16,28 @@
 
 package net.fabricmc.fabric.mixin.event.lifecycle;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.class_10961;
+
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.world.ServerWorld;
 
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerMixin {
-	@Shadow
-	private MinecraftServer.ResourceManagerHolder resourceManagerHolder;
-
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;setupServer()Z"), method = "runServer")
 	private void beforeSetupServer(CallbackInfo info) {
 		ServerLifecycleEvents.SERVER_STARTING.invoker().onServerStarting((MinecraftServer) (Object) this);
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;createMetadata()Lnet/minecraft/server/ServerMetadata;", ordinal = 0), method = "runServer")
+	@Inject(at = @At(value = "INVOKE", target = "net/minecraft/server/MinecraftServer.createMetadata(Lnet/minecraft/class_10961;)Lnet/minecraft/server/ServerMetadata;", ordinal = 0), method = "method_70561")
 	private void afterSetupServer(CallbackInfo info) {
 		ServerLifecycleEvents.SERVER_STARTED.invoker().onServerStarted((MinecraftServer) (Object) this);
 	}
@@ -64,50 +52,13 @@ public abstract class MinecraftServerMixin {
 		ServerLifecycleEvents.SERVER_STOPPED.invoker().onServerStopped((MinecraftServer) (Object) this);
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;tickWorlds(Ljava/util/function/BooleanSupplier;)V"), method = "tick")
-	private void onStartTick(BooleanSupplier shouldKeepTicking, CallbackInfo ci) {
+	@Inject(at = @At(value = "INVOKE", target = "net/minecraft/server/MinecraftServer.tickWorlds(Lnet/minecraft/class_10961;Ljava/util/function/BooleanSupplier;)V"), method = "tick")
+	private void onStartTick(class_10961 gameInstance, BooleanSupplier booleanSupplier, CallbackInfo ci) {
 		ServerTickEvents.START_SERVER_TICK.invoker().onStartTick((MinecraftServer) (Object) this);
 	}
 
 	@Inject(at = @At("TAIL"), method = "tick")
-	private void onEndTick(BooleanSupplier shouldKeepTicking, CallbackInfo info) {
+	private void onEndTick(class_10961 gameInstance, BooleanSupplier booleanSupplier, CallbackInfo ci) {
 		ServerTickEvents.END_SERVER_TICK.invoker().onEndTick((MinecraftServer) (Object) this);
-	}
-
-	@WrapOperation(method = "createWorlds", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
-	private <K, V> V onLoadWorld(Map<K, V> worlds, K registryKey, V serverWorld, Operation<V> original) {
-		final V result = original.call(worlds, registryKey, serverWorld);
-		ServerWorldEvents.LOAD.invoker().onWorldLoad((MinecraftServer) (Object) this, (ServerWorld) serverWorld);
-
-		return result;
-	}
-
-	@Inject(method = "shutdown", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerWorld;close()V"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
-	private void onUnloadWorldAtShutdown(CallbackInfo ci, Iterator<ServerWorld> worlds, ServerWorld world) {
-		ServerWorldEvents.UNLOAD.invoker().onWorldUnload((MinecraftServer) (Object) this, world);
-	}
-
-	@Inject(method = "reloadResources", at = @At("HEAD"))
-	private void startResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-		ServerLifecycleEvents.START_DATA_PACK_RELOAD.invoker().startDataPackReload((MinecraftServer) (Object) this, this.resourceManagerHolder.resourceManager());
-	}
-
-	@Inject(method = "reloadResources", at = @At("TAIL"))
-	private void endResourceReload(Collection<String> collection, CallbackInfoReturnable<CompletableFuture<Void>> cir) {
-		cir.getReturnValue().handleAsync((value, throwable) -> {
-			// Hook into fail
-			ServerLifecycleEvents.END_DATA_PACK_RELOAD.invoker().endDataPackReload((MinecraftServer) (Object) this, this.resourceManagerHolder.resourceManager(), throwable == null);
-			return value;
-		}, (MinecraftServer) (Object) this);
-	}
-
-	@Inject(method = "save", at = @At("HEAD"))
-	private void startSave(boolean suppressLogs, boolean flush, boolean force, CallbackInfoReturnable<Boolean> cir) {
-		ServerLifecycleEvents.BEFORE_SAVE.invoker().onBeforeSave((MinecraftServer) (Object) this, flush, force);
-	}
-
-	@Inject(method = "save", at = @At("TAIL"))
-	private void endSave(boolean suppressLogs, boolean flush, boolean force, CallbackInfoReturnable<Boolean> cir) {
-		ServerLifecycleEvents.AFTER_SAVE.invoker().onAfterSave((MinecraftServer) (Object) this, flush, force);
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "ChunkGeneratingMixin",
     "DataPackContentsMixin",
+    "GameInstanceMixin",
     "LivingEntityMixin",
     "MinecraftServerMixin",
     "PlayerManagerMixin",


### PR DESCRIPTION
Fixed the mixins in `MinecraftServerMixin`, and moved the load/unload, datapack, and save events to new `GameInstanceMixin`.